### PR TITLE
Fix git step's known failure when no new traces

### DIFF
--- a/config/login.yml
+++ b/config/login.yml
@@ -1,0 +1,21 @@
+# This is an example login.yml for the ruby jenkins_api_client library:
+#   https://github.com/arangamani/jenkins_api_client
+#
+# Example login.yml file in that repo:
+#   https://github.com/arangamani/jenkins_api_client/blob/master/config/login.yml.example
+
+:server_url:   https://jenkins-url.net
+:server_port:  80
+
+# Had issues using :server_ip key, was getting timeouts connecting to Jenkins w/it
+# Project README wasn't very helpful for this, but the client code has a number of
+#   useful comments on things we could do.
+# Was an option to extend the timeout, but using the :server_url key fixed my connection issue
+# Also note that `config[:server_url]` is used in `exe/collector`'s pipeline output to
+#   make those URLs complete for printing & clicking to view the pipelines themselves
+#
+# jenkins_api_client:client.rb:
+#   https://github.com/arangamani/jenkins_api_client/blob/030af8d2a3ed1298191cf50cd0c6ccb8bee2e1eb/lib/jenkins_api_client/client.rb#L45-L114
+
+:username: your-username
+:password: your-password

--- a/exe/collector
+++ b/exe/collector
@@ -218,7 +218,10 @@ puts "For branch #{branch}"
 pipeline = "platform_puppet-agent_puppet-agent-promote-to-pe_daily-#{branch}"
 regex = /^#{Regexp.escape(pipeline)}/
 pipelines = client.job.list_all.select { |job| job =~ regex }
-puts "Pipelines: #{pipelines}"
+puts "Getting data from these pipelines:"
+pipelines.each do |name|
+  puts "- #{config[:server_url]}/job/#{name}"
+end
 pipelines.each do |name|
   total = 0
 

--- a/jenkins/collector_5.5.x.Jenkinsfile
+++ b/jenkins/collector_5.5.x.Jenkinsfile
@@ -30,19 +30,27 @@ pipeline {
   environment {
     GEM_SOURCE='https://artifactory.delivery.puppetlabs.net/artifactory/api/gems/rubygems/'
     RUBY_VERSION='2.5.1'
-    PIPELINE_BRANCH='dt_job_01'
-    GIT_CHANGED_FILES='0' // will be overriden
     BRANCH='5.5.x'
   }
 
   stages {
     stage('bundle install') {
       steps {
+        // dev mode: to iterate on the job w/o creating commits, I find it better to switch
+        //   the job from an SCM Pipeline to a Pipeline script. When that's the case, you'll
+        //   need to have a manual checkout step in your Jenkinsfile
+        //   TODO needs confirmation (does having a git project on the job mean we don't need this?)
+        // git branch: "dt_job_02",
+        //     url: 'git@github.com:kevpl/pipeline_stats.git'
         sh bundleInstall(env.RUBY_VERSION)
       }
     }
     stage('collect traces') {
       environment {
+        // credentials defined as jenkins_api_client's login.yml file
+        //   on jenkins-pipeline, these are kept here:
+        //   https://cinext-jenkinsmaster-pipeline-prod-1.delivery.puppetlabs.net/credentials/store/system/domain/_/credential/jenkins_api_client-login/
+        //   an example of the config file format is in this repo: /config/login.yml
         PIPELINE_STATS_LOGIN_FILE=credentials('jenkins_api_client-login')
       }
       steps {
@@ -50,12 +58,8 @@ pipeline {
       }
     }
     stage('commit new traces to project') {
-      // when { environment name: 'GIT_CHANGED_FILES', value: '1' }
       steps {
-        sh 'git status'
-        sh 'git add build_traces'
-        sh "git commit -m 'add new puppet-agent-${env.BRANCH} traces'"
-        sh "git push origin ${env.PIPELINE_BRANCH}"
+        sh 'jenkins/git_commit.sh'
       }
     }
   }

--- a/jenkins/collector_master.Jenkinsfile
+++ b/jenkins/collector_master.Jenkinsfile
@@ -30,19 +30,27 @@ pipeline {
   environment {
     GEM_SOURCE='https://artifactory.delivery.puppetlabs.net/artifactory/api/gems/rubygems/'
     RUBY_VERSION='2.5.1'
-    PIPELINE_BRANCH='dt_job_01'
-    GIT_CHANGED_FILES='0' // will be overriden
     BRANCH='master'
   }
 
   stages {
     stage('bundle install') {
       steps {
+        // dev mode: to iterate on the job w/o creating commits, I find it better to switch
+        //   the job from an SCM Pipeline to a Pipeline script. When that's the case, you'll
+        //   need to have a manual checkout step in your Jenkinsfile
+        //   TODO needs confirmation (does having a git project on the job mean we don't need this?)
+        // git branch: "dt_job_02",
+        //     url: 'git@github.com:kevpl/pipeline_stats.git'
         sh bundleInstall(env.RUBY_VERSION)
       }
     }
     stage('collect traces') {
       environment {
+        // credentials defined as jenkins_api_client's login.yml file
+        //   on jenkins-pipeline, these are kept here:
+        //   https://cinext-jenkinsmaster-pipeline-prod-1.delivery.puppetlabs.net/credentials/store/system/domain/_/credential/jenkins_api_client-login/
+        //   an example of the config file format is in this repo: /config/login.yml
         PIPELINE_STATS_LOGIN_FILE=credentials('jenkins_api_client-login')
       }
       steps {
@@ -50,12 +58,8 @@ pipeline {
       }
     }
     stage('commit new traces to project') {
-      // when { environment name: 'GIT_CHANGED_FILES', value: '1' }
       steps {
-        sh 'git status'
-        sh 'git add build_traces'
-        sh "git commit -m 'add new puppet-agent-${env.BRANCH} traces'"
-        sh "git push origin ${env.PIPELINE_BRANCH}"
+        sh 'jenkins/git_commit.sh'
       }
     }
   }

--- a/jenkins/git_commit.sh
+++ b/jenkins/git_commit.sh
@@ -2,11 +2,12 @@
 
 set -e -x
 
+git status
+
 git diff-index --quiet HEAD
 files_changed=$?
 if [ $files_changed -ne 0 ]; then
-    echo "git_commit.sh detected new build traces. git status:"
-    git status
+    echo "** git_commit.sh ** detected new build traces. Committing to git repo..."
     git add build_traces
     git commit -m "add new puppet-agent-${BRANCH} traces"
     git push origin $PIPELINE_BRANCH

--- a/jenkins/git_commit.sh
+++ b/jenkins/git_commit.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -e -x
+
+git diff-index --quiet HEAD
+files_changed=$?
+if [ $files_changed -ne 0 ]; then
+    echo "git_commit.sh detected new build traces. git status:"
+    git status
+    git add build_traces
+    git commit -m "add new puppet-agent-${BRANCH} traces"
+    git push origin $PIPELINE_BRANCH
+else
+    echo "NO additional build_trace files. Job Complete"
+    exit 0
+fi


### PR DESCRIPTION
This change fixes a known issue in the Distributed Tracing jobs where if there are no new trace files to commit, the build would report a failure since the `git commit` wouldn't succeed. It does this by running the git commands in a small bash script (ref: `git_commit.sh`) that runs a command to detect changes on the file system & run the appropriate actions. Thanks @genebean for the advice to try getting my head out of the pipeline-only clouds!

There are some additional documentation updates added in as well, hopefully to make these easier to deal with for others in the future. Note about the `dev mode` comment: I'm not certain that this claim is true (as mentioned in the `TODO` line below it), but I thought it would be better to be over-verbose & be OK with deleting those lines later rather than being too sparse & wasting someone's time who might need it.

These changes are running on the [Distributed Tracing: Collector: Master job](https://cinext-jenkinsmaster-pipeline-prod-1.delivery.puppetlabs.net/view/Distributed%20Tracing/job/dt_collector_master) now from this PR branch ([build #10](https://cinext-jenkinsmaster-pipeline-prod-1.delivery.puppetlabs.net/view/Distributed%20Tracing/job/dt_collector_master/10/) is the build that ran w/this code)